### PR TITLE
Fix dangling HttpRequest nodes (3.x)

### DIFF
--- a/addons/copilot/OpenAICompletion.gd
+++ b/addons/copilot/OpenAICompletion.gd
@@ -52,14 +52,13 @@ func get_completion(_prompt, _suffix):
 	]
 	var http_request = HTTPRequest.new()
 	add_child(http_request)
-	http_request.connect("request_completed",self,"on_request_completed", [_prompt, _suffix])
+	http_request.connect("request_completed",self,"on_request_completed", [_prompt, _suffix, http_request])
 	var json_body = JSON.print(body)
-	var buffer = json_body.to_utf8()
 	var error = http_request.request(URL, headers, false, HTTPClient.METHOD_POST, json_body)
 	if error != OK:
 		emit_signal("completion_error", null)
 
-func on_request_completed(result, response_code, headers, body, pre, post):
+func on_request_completed(result, response_code, headers, body, pre, post, http_request):
 	var test_json_conv = JSON.parse(body.get_string_from_utf8())
 	var json = test_json_conv.result
 	var response = json
@@ -67,4 +66,6 @@ func on_request_completed(result, response_code, headers, body, pre, post):
 		emit_signal("completion_error", response)
 		return
 	var completion = response.choices[0].text
+	if is_instance_valid(http_request):
+		http_request.queue_free()
 	emit_signal("completion_received", completion, pre, post)


### PR DESCRIPTION
Addresses #3 

- Free `HttpRequest` nodes after request completion
- Remove useless buffer creation