### PR TITLE
Support GitHub Copilot Tokens

### DIFF
--- a/addons/copilot/Copilot.gd
+++ b/addons/copilot/Copilot.gd
@@ -8,8 +8,10 @@ extends Control
 @onready var shortcut_modifier_select = $VBoxParent/ShortcutSetting/HBoxContainer/Modifier
 @onready var shortcut_key_select = $VBoxParent/ShortcutSetting/HBoxContainer/Key
 @onready var multiline_toggle = $VBoxParent/MultilineSetting/Multiline
+@onready var openai_key_title = $VBoxParent/OpenAiSetting/Label
 @onready var openai_key_input = $VBoxParent/OpenAiSetting/OpenAiKey
 @onready var version_label = $Version
+@onready var info = $VBoxParent/Info
 
 @export var icon_shader : ShaderMaterial
 @export var highlight_color : Color
@@ -30,6 +32,7 @@ var allow_multiline = true
 
 const PREFERENCES_STORAGE_NAME = "user://copilot.cfg"
 const PREFERENCES_PASS = "F4fv2Jxpasp20VS5VSp2Yp2v9aNVJ21aRK"
+const GITHUB_COPILOT_DISCLAIMER = "Use GitHub Copilot keys at your own risk. Retrieve key by following instructions [url=https://github.com/aaamoon/copilot-gpt4-service?tab=readme-ov-file#obtaining-copilot-token]here[/url]."
 
 func _ready():
 	#Initialize dock, load settings
@@ -264,6 +267,14 @@ func set_openai_api_key(key):
 func set_model(model_name):
 	#Apply selected model
 	cur_model = model_name
+	# Handle some special model scenarios
+	if "github-copilot" in model_name:
+		openai_key_title.text = "GitHub Copilot API Key"
+		info.parse_bbcode(GITHUB_COPILOT_DISCLAIMER)
+		info.show()
+	else:
+		openai_key_title.text = "OpenAI API Key"
+		info.hide()
 
 func set_shortcut_modifier(modifier):
 	#Apply selected shortcut modifier
@@ -333,6 +344,7 @@ func load_config():
 	if err != OK: return
 	cur_model = config.get_value("preferences", "model", cur_model)
 	apply_by_value(model_select, cur_model)
+	set_model(model_select.get_item_text(model_select.selected))
 	cur_shortcut_modifier = config.get_value("preferences", "shortcut_modifier", cur_shortcut_modifier)
 	apply_by_value(shortcut_modifier_select, cur_shortcut_modifier)
 	cur_shortcut_key = config.get_value("preferences", "shortcut_key", cur_shortcut_key)
@@ -350,3 +362,7 @@ func apply_by_value(option_button, value):
 
 func set_version(version):
 	version_label.text = "v%s" % version
+
+
+func on_info_meta_clicked(meta):
+	OS.shell_open(meta)

--- a/addons/copilot/CopilotUI.tscn
+++ b/addons/copilot/CopilotUI.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=6 format=3 uid="uid://rv5dl08lcb8e"]
+[gd_scene load_steps=7 format=3 uid="uid://rv5dl08lcb8e"]
 
 [ext_resource type="Script" path="res://addons/copilot/Copilot.gd" id="1_pq1gj"]
 [ext_resource type="Script" path="res://addons/copilot/OpenAIChat.gd" id="2"]
 [ext_resource type="Material" uid="uid://cccmbprav6vgu" path="res://addons/copilot/small_icon.tres" id="2_gdw4j"]
 [ext_resource type="Script" path="res://addons/copilot/OpenAICompletion.gd" id="3_loa2x"]
 [ext_resource type="Material" uid="uid://bl1rtf743e4l3" path="res://addons/copilot/large_icon.tres" id="3_xn70b"]
+[ext_resource type="Script" path="res://addons/copilot/GithubCopilot.gd" id="6_hmh8w"]
 
 [node name="Copilot" type="Control"]
 layout_mode = 3
@@ -249,6 +250,12 @@ size_flags_horizontal = 10
 button_pressed = true
 text = "Enabled"
 
+[node name="Info" type="RichTextLabel" parent="VBoxParent"]
+layout_mode = 2
+focus_mode = 2
+fit_content = true
+selection_enabled = true
+
 [node name="LLMs" type="Node" parent="."]
 
 [node name="OpenAICompletion" type="Node" parent="LLMs"]
@@ -256,6 +263,9 @@ script = ExtResource("3_loa2x")
 
 [node name="OpenAIChat" type="Node" parent="LLMs"]
 script = ExtResource("2")
+
+[node name="GithubCopilot" type="Node" parent="LLMs"]
+script = ExtResource("6_hmh8w")
 
 [node name="Version" type="Label" parent="."]
 layout_mode = 1
@@ -274,7 +284,10 @@ vertical_alignment = 2
 [connection signal="item_selected" from="VBoxParent/ShortcutSetting/HBoxContainer/Modifier" to="." method="_on_shortcut_modifier_selected"]
 [connection signal="item_selected" from="VBoxParent/ShortcutSetting/HBoxContainer/Key" to="." method="_on_shortcut_key_selected"]
 [connection signal="toggled" from="VBoxParent/MultilineSetting/Multiline" to="." method="_on_multiline_toggled"]
+[connection signal="meta_clicked" from="VBoxParent/Info" to="." method="on_info_meta_clicked"]
 [connection signal="completion_error" from="LLMs/OpenAICompletion" to="." method="_on_code_completion_error"]
 [connection signal="completion_received" from="LLMs/OpenAICompletion" to="." method="_on_code_completion_received"]
 [connection signal="completion_error" from="LLMs/OpenAIChat" to="." method="_on_code_completion_error"]
 [connection signal="completion_received" from="LLMs/OpenAIChat" to="." method="_on_code_completion_received"]
+[connection signal="completion_error" from="LLMs/GithubCopilot" to="." method="_on_code_completion_error"]
+[connection signal="completion_received" from="LLMs/GithubCopilot" to="." method="_on_code_completion_received"]

--- a/addons/copilot/GithubCopilot.gd
+++ b/addons/copilot/GithubCopilot.gd
@@ -1,0 +1,189 @@
+@tool
+extends "res://addons/copilot/LLM.gd"
+
+const URL = "https://api.githubcopilot.com/chat/completions"
+const AUTH_URL = "https://api.github.com/copilot_internal/v2/token"
+const SYSTEM_TEMPLATE = """You are a brilliant coding assistant for the game-engine Godot. The version used is Godot 4.0, and all code must be valid GDScript!
+That means the new GDScript 2.0 syntax is used. Here's a couple of important changes that were introduced:
+- Use @export annotation for exports
+- Use Node3D instead of Spatial, and position instead of translation
+- Use randf_range and randi_range instead of rand_range
+- Connect signals via node.SIGNAL_NAME.connect(Callable(TARGET_OBJECT, TARGET_FUNC))
+- Same for sort_custom calls, pass a Callable(TARGET_OBJECT, TARGET_FUNC)
+- Use rad_to_deg instead of rad2deg
+- Use PackedByteArray instead of PoolByteArray
+- Use instantiate instead of instance
+- You can't use enumerate(OBJECT). Instead, use "for i in len(OBJECT):"
+
+Remember, this is not Python. It's GDScript for use in Godot.
+
+You may only answer in code, never add any explanations. In your prompt, there will be an !INSERT_CODE_HERE! tag. Only respond with plausible code that may be inserted at that point. Never repeat the full script, only the parts to be inserted. Treat this as if it was an autocompletion. You may continue whatever word or expression was left unfinished before the tag. Make sure indentation matches the surrounding context."""
+const INSERT_TAG = "!INSERT_CODE_HERE!"
+const MAX_LENGTH = 8500
+
+const PREFERENCES_STORAGE_NAME = "user://github_copilot_llm.cfg"
+const PREFERENCES_PASS = "Jr55ICpdp3M3CuWHX0WHLqg3yh4XBjbXX"
+
+var machine_id
+var session_id
+var auth_token
+
+signal auth_token_retrieved
+
+class Message:
+	var role: String
+	var content: String
+	
+	func get_json():
+		return {
+			"role": role,
+			"content": content
+		}
+
+const ROLES = {
+	"SYSTEM": "system",
+	"USER": "user",
+	"ASSISTANT": "assistant"
+}
+
+func _get_models():
+	return [
+		"gpt-4-github-copilot"
+	]
+
+func _set_model(model_name):
+	model = model_name.replace("github-copilot", "")
+
+func _send_user_prompt(user_prompt, user_suffix):
+	var messages = format_prompt(user_prompt, user_suffix)
+	get_completion(messages, user_prompt, user_suffix)
+
+func format_prompt(prompt, suffix):
+	var messages = []
+	var system_prompt = SYSTEM_TEMPLATE
+	
+	var combined_prompt = prompt + suffix
+	var diff = combined_prompt.length() - MAX_LENGTH
+	if diff > 0:
+		if suffix.length() > diff:
+			suffix = suffix.substr(0,diff)
+		else:
+			prompt = prompt.substr(diff - suffix.length())
+			suffix = ""
+	var user_prompt = prompt + INSERT_TAG + suffix
+	
+	var msg = Message.new()
+	msg.role = ROLES.SYSTEM
+	msg.content = system_prompt
+	messages.append(msg.get_json())
+	
+	msg = Message.new()
+	msg.role = ROLES.USER
+	msg.content = user_prompt
+	messages.append(msg.get_json())
+	
+	return messages
+	
+func gen_hex_str(length: int) -> String:
+	var rng = RandomNumberGenerator.new()
+	var result = PackedByteArray()
+	for i in range(length / 2):
+		result.push_back(rng.randi_range(0, 255))
+	var hex_str = ""
+	for byte in result:
+		hex_str += "%02x" % byte
+	return hex_str
+
+func create_headers(token: String, stream: bool):
+	var contentType: String = "application/json; charset=utf-8"
+	if stream:
+		contentType = "text/event-stream; charset=utf-8"
+
+	load_config()
+	var uuidString: String = UUID.v4()
+
+	return [
+		"Authorization: %s" % ("Bearer " + token),
+		"X-Request-Id: %s" % uuidString,
+		"Vscode-Sessionid: %s" % session_id,
+		"Vscode-Machineid: %s" % machine_id,
+		"Editor-Version: vscode/1.83.1",
+		"Editor-Plugin-Version: copilot-chat/0.8.0",
+		"Openai-Organization: github-copilot",
+		"Openai-Intent: conversation-panel",
+		"Content-Type: %s" % contentType,
+		"User-Agent: GitHubCopilotChat/0.8.0",
+		"Accept: */*",
+		"Accept-Encoding: gzip,deflate,br",
+		"Connection: close"
+	]
+
+func get_auth():
+	var headers = [
+		"Accept-Encoding: gzip",
+		"Authorization: token %s" % api_key
+	]
+	var http_request = HTTPRequest.new()
+	add_child(http_request)
+	http_request.connect("request_completed",on_auth_request_completed)
+	var error = http_request.request(AUTH_URL, headers, HTTPClient.METHOD_GET)
+	if error != OK:
+		emit_signal("completion_error", null)
+
+func get_completion(messages, prompt, suffix):
+	if not auth_token:
+		get_auth()
+		await auth_token_retrieved
+	
+	var body = {
+		"model": model,
+		"messages": messages,
+		"temperature": 0.7,
+		"top_p": 1,
+		"n": 1,
+		"stream": false,
+	}
+	var headers = create_headers(auth_token, false)
+	var http_request = HTTPRequest.new()
+	add_child(http_request)
+	http_request.connect("request_completed",on_request_completed.bind(prompt, suffix, http_request))
+	var json_body = JSON.stringify(body)
+	var error = http_request.request(URL, headers, HTTPClient.METHOD_POST, json_body)
+	if error != OK:
+		emit_signal("completion_error", null)
+
+func on_auth_request_completed(result, response_code, headers, body):
+	var test_json_conv = JSON.new()
+	test_json_conv.parse(body.get_string_from_utf8())
+	var json = test_json_conv.get_data()
+	auth_token = json.token
+	auth_token_retrieved.emit()
+
+func on_request_completed(result, response_code, headers, body, pre, post, http_request):
+	var test_json_conv = JSON.new()
+	test_json_conv.parse(body.get_string_from_utf8())
+	var json = test_json_conv.get_data()
+	var response = json
+	if !response.has("choices") :
+		emit_signal("completion_error", response)
+		return
+	var completion = response.choices[0].message
+	if is_instance_valid(http_request):
+		http_request.queue_free()
+	emit_signal("completion_received", completion.content, pre, post)
+
+func store_config():
+	var config = ConfigFile.new()
+	config.set_value("auth", "machine_id", machine_id)
+	config.save_encrypted_pass(PREFERENCES_STORAGE_NAME, PREFERENCES_PASS)
+	
+func load_config():
+	var config = ConfigFile.new()
+	var err = config.load_encrypted_pass(PREFERENCES_STORAGE_NAME, PREFERENCES_PASS)
+	if not session_id:
+		session_id = gen_hex_str(8) + "-" + gen_hex_str(4) + "-" + gen_hex_str(4) + "-" + gen_hex_str(4) + "-" + gen_hex_str(25)
+	if err != OK:
+		machine_id = UUID.v4()
+		store_config()
+		return
+	machine_id = config.get_value("auth", "machine_id", UUID.v4())

--- a/addons/copilot/UUID.gd
+++ b/addons/copilot/UUID.gd
@@ -1,0 +1,117 @@
+# From: https://github.com/binogure-studio/godot-uuid
+# Credit: binogure-studio
+
+# Note: The code might not be as pretty it could be, since it's written
+# in a way that maximizes performance. Methods are inlined and loops are avoided.
+extends Node
+class_name UUID
+
+const BYTE_MASK: int = 0b11111111
+
+static func uuidbin():
+  # 16 random bytes with the bytes on index 6 and 8 modified
+	return [
+		randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK,
+		randi() & BYTE_MASK, randi() & BYTE_MASK, ((randi() & BYTE_MASK) & 0x0f) | 0x40, randi() & BYTE_MASK,
+		((randi() & BYTE_MASK) & 0x3f) | 0x80, randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK,
+		randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK, randi() & BYTE_MASK,
+	]
+
+static func uuidbinrng(rng: RandomNumberGenerator):
+	return [
+		rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK,
+		rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, ((rng.randi() & BYTE_MASK) & 0x0f) | 0x40, rng.randi() & BYTE_MASK,
+		((rng.randi() & BYTE_MASK) & 0x3f) | 0x80, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK,
+		rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK, rng.randi() & BYTE_MASK,
+	]
+
+static func v4():
+	# 16 random bytes with the bytes on index 6 and 8 modified
+	var b = uuidbin()
+
+	return '%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x' % [
+	# low
+	b[0], b[1], b[2], b[3],
+
+	# mid
+	b[4], b[5],
+
+	# hi
+	b[6], b[7],
+
+	# clock
+	b[8], b[9],
+
+	# clock
+	b[10], b[11], b[12], b[13], b[14], b[15]
+	]
+  
+static func v4_rng(rng: RandomNumberGenerator):
+  # 16 random bytes with the bytes on index 6 and 8 modified
+	var b = uuidbinrng(rng)
+
+	return '%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x' % [
+	# low
+	b[0], b[1], b[2], b[3],
+
+	# mid
+	b[4], b[5],
+
+	# hi
+	b[6], b[7],
+
+	# clock
+	b[8], b[9],
+
+	# clock
+	b[10], b[11], b[12], b[13], b[14], b[15]
+  ]
+  
+var _uuid: Array
+
+func _init(rng := RandomNumberGenerator.new()) -> void:
+	_uuid = uuidbinrng(rng)
+
+func as_array() -> Array:
+	return _uuid.duplicate()
+
+func as_dict(big_endian := true) -> Dictionary:
+	if big_endian:
+		return {
+			"low"  : (_uuid[0]  << 24) + (_uuid[1]  << 16) + (_uuid[2]  << 8 ) +  _uuid[3],
+			"mid"  : (_uuid[4]  << 8 ) +  _uuid[5],
+			"hi"   : (_uuid[6]  << 8 ) +  _uuid[7],
+			"clock": (_uuid[8]  << 8 ) +  _uuid[9],
+			"node" : (_uuid[10] << 40) + (_uuid[11] << 32) + (_uuid[12] << 24) + (_uuid[13] << 16) + (_uuid[14] << 8 ) +  _uuid[15]
+		}
+	else:
+		return {
+			"low"  : _uuid[0]          + (_uuid[1]  << 8 ) + (_uuid[2]  << 16) + (_uuid[3]  << 24),
+			"mid"  : _uuid[4]          + (_uuid[5]  << 8 ),
+			"hi"   : _uuid[6]          + (_uuid[7]  << 8 ),
+			"clock": _uuid[8]          + (_uuid[9]  << 8 ),
+			"node" : _uuid[10]         + (_uuid[11] << 8 ) + (_uuid[12] << 16) + (_uuid[13] << 24) + (_uuid[14] << 32) + (_uuid[15] << 40)
+		}
+	
+func as_string() -> String:
+	return '%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x' % [
+	# low
+	_uuid[0], _uuid[1], _uuid[2], _uuid[3],
+
+	# mid
+	_uuid[4], _uuid[5],
+
+	# hi
+	_uuid[6], _uuid[7],
+
+	# clock
+	_uuid[8], _uuid[9],
+
+	# node
+	_uuid[10], _uuid[11], _uuid[12], _uuid[13], _uuid[14], _uuid[15]
+  ]
+  
+func is_equal(other) -> bool:
+  # Godot Engine compares Array recursively
+  # There's no need for custom comparison here.
+	return _uuid == other._uuid

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Godot Copilot"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 config/icon="res://icon.png"
 
 [editor_plugins]


### PR DESCRIPTION
Resolves #7 

- Adds support for tokens extracted from GitHub Copilot service
  - Adds `GithubCopilot`LLM option and `gpt-4-github-copilot` model
  - Adds machine id persistence and UUID generation for other required session ids
  - Adds support for necessary authentication and completion endpoints
  - Adds disclaimer in Godot Copilot UI
- **Use at your own risk. Using GitHub Copilot beyond its original intended scope may lead to account bans.**