### PR TITLE
Add support for Llama and WizardLLM models

### DIFF
--- a/addons/copilot/CopilotUI.tscn
+++ b/addons/copilot/CopilotUI.tscn
@@ -115,7 +115,7 @@ layout_mode = 2
 [node name="Model" type="OptionButton" parent="VBoxParent/ModelSetting"]
 layout_mode = 2
 size_flags_horizontal = 10
-item_count = 3
+item_count = 4
 selected = 1
 fit_to_longest_item = false
 popup/item_0/text = "text-davinci-003"
@@ -124,6 +124,8 @@ popup/item_1/text = "gpt-3.5-turbo"
 popup/item_1/id = 1
 popup/item_2/text = "gpt-4"
 popup/item_2/id = 2
+popup/item_3/text = "llama3.2"
+popup/item_3/id = 3
 
 [node name="ShortcutSetting" type="HBoxContainer" parent="VBoxParent"]
 custom_minimum_size = Vector2(2.08165e-12, 2.08165e-12)

--- a/addons/copilot/CopilotUI.tscn
+++ b/addons/copilot/CopilotUI.tscn
@@ -6,6 +6,8 @@
 [ext_resource type="Script" path="res://addons/copilot/OpenAICompletion.gd" id="3_loa2x"]
 [ext_resource type="Material" uid="uid://bl1rtf743e4l3" path="res://addons/copilot/large_icon.tres" id="3_xn70b"]
 [ext_resource type="Script" path="res://addons/copilot/GithubCopilot.gd" id="6_hmh8w"]
+[ext_resource type="Script" path="res://addons/copilot/Llama.gd" id="7"]
+[ext_resource type="Script" path="res://addons/copilot/WizardLLM.gd" id="8"]
 
 [node name="Copilot" type="Control"]
 layout_mode = 3
@@ -267,6 +269,12 @@ script = ExtResource("2")
 [node name="GithubCopilot" type="Node" parent="LLMs"]
 script = ExtResource("6_hmh8w")
 
+[node name="Llama" type="Node" parent="LLMs"]
+script = ExtResource("7")
+
+[node name="WizardLLM" type="Node" parent="LLMs"]
+script = ExtResource("8")
+
 [node name="Version" type="Label" parent="."]
 layout_mode = 1
 anchors_preset = 12
@@ -291,3 +299,7 @@ vertical_alignment = 2
 [connection signal="completion_received" from="LLMs/OpenAIChat" to="." method="_on_code_completion_received"]
 [connection signal="completion_error" from="LLMs/GithubCopilot" to="." method="_on_code_completion_error"]
 [connection signal="completion_received" from="LLMs/GithubCopilot" to="." method="_on_code_completion_received"]
+[connection signal="completion_error" from="LLMs/Llama" to="." method="_on_code_completion_error"]
+[connection signal="completion_received" from="LLMs/Llama" to="." method="_on_code_completion_received"]
+[connection signal="completion_error" from="LLMs/WizardLLM" to="." method="_on_code_completion_error"]
+[connection signal="completion_received" from="LLMs/WizardLLM" to="." method="_on_code_completion_received"]

--- a/addons/copilot/Llama.gd
+++ b/addons/copilot/Llama.gd
@@ -41,7 +41,8 @@ func _get_models():
 		"llama-7b",
 		"llama-13b",
 		"llama-30b",
-		"llama-65b"
+		"llama-65b",
+		"llama3.2"
 	]
 
 func _set_model(model_name):

--- a/addons/copilot/Llama.gd
+++ b/addons/copilot/Llama.gd
@@ -1,0 +1,111 @@
+@tool
+extends "res://addons/copilot/LLM.gd"
+
+const URL = "http://localhost:5000/api/llama"
+const SYSTEM_TEMPLATE = """You are a brilliant coding assistant for the game-engine Godot. The version used is Godot 4.0, and all code must be valid GDScript!
+That means the new GDScript 2.0 syntax is used. Here's a couple of important changes that were introduced:
+- Use @export annotation for exports
+- Use Node3D instead of Spatial, and position instead of translation
+- Use randf_range and randi_range instead of rand_range
+- Connect signals via node.SIGNAL_NAME.connect(Callable(TARGET_OBJECT, TARGET_FUNC))
+- Same for sort_custom calls, pass a Callable(TARGET_OBJECT, TARGET_FUNC)
+- Use rad_to_deg instead of rad2deg
+- Use PackedByteArray instead of PoolByteArray
+- Use instantiate instead of instance
+- You can't use enumerate(OBJECT). Instead, use "for i in len(OBJECT):"
+
+Remember, this is not Python. It's GDScript for use in Godot.
+
+You may only answer in code, never add any explanations. In your prompt, there will be an !INSERT_CODE_HERE! tag. Only respond with plausible code that may be inserted at that point. Never repeat the full script, only the parts to be inserted. Treat this as if it was an autocompletion. You may continue whatever word or expression was left unfinished before the tag. Make sure indentation matches the surrounding context."""
+const INSERT_TAG = "!INSERT_CODE_HERE!"
+const MAX_LENGTH = 8500
+
+class Message:
+	var role: String
+	var content: String
+	
+	func get_json():
+		return {
+			"role": role,
+			"content": content
+		}
+
+const ROLES = {
+	"SYSTEM": "system",
+	"USER": "user",
+	"ASSISTANT": "assistant"
+}
+
+func _get_models():
+	return [
+		"llama-7b",
+		"llama-13b",
+		"llama-30b",
+		"llama-65b"
+	]
+
+func _set_model(model_name):
+	model = model_name
+
+func _send_user_prompt(user_prompt, user_suffix):
+	var messages = format_prompt(user_prompt, user_suffix)
+	get_completion(messages, user_prompt, user_suffix)
+
+func format_prompt(prompt, suffix):
+	var messages = []
+	var system_prompt = SYSTEM_TEMPLATE
+	
+	var combined_prompt = prompt + suffix
+	var diff = combined_prompt.length() - MAX_LENGTH
+	if diff > 0:
+		if suffix.length() > diff:
+			suffix = suffix.substr(0,diff)
+		else:
+			prompt = prompt.substr(diff - suffix.length())
+			suffix = ""
+	var user_prompt = prompt + INSERT_TAG + suffix
+	
+	var msg = Message.new()
+	msg.role = ROLES.SYSTEM
+	msg.content = system_prompt
+	messages.append(msg.get_json())
+	
+	msg = Message.new()
+	msg.role = ROLES.USER
+	msg.content = user_prompt
+	messages.append(msg.get_json())
+	
+	return messages
+
+func get_completion(messages, prompt, suffix):
+	var body = {
+		"model": model,
+		"messages": messages,
+		"temperature": 0.7,
+		"max_tokens": 500,
+		"stop": "\n\n" if allow_multiline else "\n" 
+	}
+	var headers = [
+		"Content-Type: application/json",
+		"Authorization: Bearer %s" % api_key
+	]
+	var http_request = HTTPRequest.new()
+	add_child(http_request)
+	http_request.connect("request_completed",on_request_completed.bind(prompt, suffix, http_request))
+	var json_body = JSON.stringify(body)
+	var error = http_request.request(URL, headers, HTTPClient.METHOD_POST, json_body)
+	if error != OK:
+		emit_signal("completion_error", null)
+
+func on_request_completed(result, response_code, headers, body, pre, post, http_request):
+	var test_json_conv = JSON.new()
+	test_json_conv.parse(body.get_string_from_utf8())
+	var json = test_json_conv.get_data()
+	var response = json
+	if !response.has("choices"):
+		emit_signal("completion_error", response)
+		return
+	var completion = response.choices[0].message
+	if is_instance_valid(http_request):
+		http_request.queue_free()
+	emit_signal("completion_received", completion.content, pre, post)

--- a/addons/copilot/WizardLLM.gd
+++ b/addons/copilot/WizardLLM.gd
@@ -1,0 +1,111 @@
+@tool
+extends "res://addons/copilot/LLM.gd"
+
+const URL = "http://localhost:5000/api/wizardllm"
+const SYSTEM_TEMPLATE = """You are a brilliant coding assistant for the game-engine Godot. The version used is Godot 4.0, and all code must be valid GDScript!
+That means the new GDScript 2.0 syntax is used. Here's a couple of important changes that were introduced:
+- Use @export annotation for exports
+- Use Node3D instead of Spatial, and position instead of translation
+- Use randf_range and randi_range instead of rand_range
+- Connect signals via node.SIGNAL_NAME.connect(Callable(TARGET_OBJECT, TARGET_FUNC))
+- Same for sort_custom calls, pass a Callable(TARGET_OBJECT, TARGET_FUNC)
+- Use rad_to_deg instead of rad2deg
+- Use PackedByteArray instead of PoolByteArray
+- Use instantiate instead of instance
+- You can't use enumerate(OBJECT). Instead, use "for i in len(OBJECT):"
+
+Remember, this is not Python. It's GDScript for use in Godot.
+
+You may only answer in code, never add any explanations. In your prompt, there will be an !INSERT_CODE_HERE! tag. Only respond with plausible code that may be inserted at that point. Never repeat the full script, only the parts to be inserted. Treat this as if it was an autocompletion. You may continue whatever word or expression was left unfinished before the tag. Make sure indentation matches the surrounding context."""
+const INSERT_TAG = "!INSERT_CODE_HERE!"
+const MAX_LENGTH = 8500
+
+class Message:
+	var role: String
+	var content: String
+	
+	func get_json():
+		return {
+			"role": role,
+			"content": content
+		}
+
+const ROLES = {
+	"SYSTEM": "system",
+	"USER": "user",
+	"ASSISTANT": "assistant"
+}
+
+func _get_models():
+	return [
+		"wizard-7b",
+		"wizard-13b",
+		"wizard-30b",
+		"wizard-65b"
+	]
+
+func _set_model(model_name):
+	model = model_name
+
+func _send_user_prompt(user_prompt, user_suffix):
+	var messages = format_prompt(user_prompt, user_suffix)
+	get_completion(messages, user_prompt, user_suffix)
+
+func format_prompt(prompt, suffix):
+	var messages = []
+	var system_prompt = SYSTEM_TEMPLATE
+	
+	var combined_prompt = prompt + suffix
+	var diff = combined_prompt.length() - MAX_LENGTH
+	if diff > 0:
+		if suffix.length() > diff:
+			suffix = suffix.substr(0,diff)
+		else:
+			prompt = prompt.substr(diff - suffix.length())
+			suffix = ""
+	var user_prompt = prompt + INSERT_TAG + suffix
+	
+	var msg = Message.new()
+	msg.role = ROLES.SYSTEM
+	msg.content = system_prompt
+	messages.append(msg.get_json())
+	
+	msg = Message.new()
+	msg.role = ROLES.USER
+	msg.content = user_prompt
+	messages.append(msg.get_json())
+	
+	return messages
+
+func get_completion(messages, prompt, suffix):
+	var body = {
+		"model": model,
+		"messages": messages,
+		"temperature": 0.7,
+		"max_tokens": 500,
+		"stop": "\n\n" if allow_multiline else "\n" 
+	}
+	var headers = [
+		"Content-Type: application/json",
+		"Authorization: Bearer %s" % api_key
+	]
+	var http_request = HTTPRequest.new()
+	add_child(http_request)
+	http_request.connect("request_completed",on_request_completed.bind(prompt, suffix, http_request))
+	var json_body = JSON.stringify(body)
+	var error = http_request.request(URL, headers, HTTPClient.METHOD_POST, json_body)
+	if error != OK:
+		emit_signal("completion_error", null)
+
+func on_request_completed(result, response_code, headers, body, pre, post, http_request):
+	var test_json_conv = JSON.new()
+	test_json_conv.parse(body.get_string_from_utf8())
+	var json = test_json_conv.get_data()
+	var response = json
+	if !response.has("choices"):
+		emit_signal("completion_error", response)
+		return
+	var completion = response.choices[0].message
+	if is_instance_valid(http_request):
+		http_request.queue_free()
+	emit_signal("completion_received", completion.content, pre, post)


### PR DESCRIPTION
Fixes #15

Add support for self-hosted generative models Llama and WizardLLM.

* **Add Llama model support:**
  - Create `addons/copilot/Llama.gd` script.
  - Implement `_get_models`, `_set_model`, `_send_user_prompt` functions.
  - Define constants and helper functions for Llama model.

* **Add WizardLLM model support:**
  - Create `addons/copilot/WizardLLM.gd` script.
  - Implement `_get_models`, `_set_model`, `_send_user_prompt` functions.
  - Define constants and helper functions for WizardLLM model.

* **Update Copilot.gd:**
  - Modify `populate_models` function to include Llama and WizardLLM models.
  - Add Llama and WizardLLM to the `models` dictionary.

* **Update CopilotUI.tscn:**
  - Add Llama and WizardLLM nodes to the `LLMs` node.
  - Set the script for Llama and WizardLLM nodes to the respective new scripts.
  - Add signal connections for Llama and WizardLLM nodes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/minosvasilias/godot-copilot/issues/15?shareId=0ee97872-361e-4cf6-9997-5d4324f46168).